### PR TITLE
[BUGFIX] Deltas must not have current rollup, remove server uptime delta

### DIFF
--- a/src/main/java/com/appdynamics/monitors/apache/ApacheStatusMonitor.java
+++ b/src/main/java/com/appdynamics/monitors/apache/ApacheStatusMonitor.java
@@ -400,10 +400,6 @@ public class ApacheStatusMonitor extends AManagedMonitor {
 
         String curUptime = valueMap.get("Uptime");
         printCollectiveObservedCurrent(metricPrefix + "Availability|Server Uptime (sec)", curUptime);
-        BigInteger prevUptime = processDelta(metricPrefix + "Availability|Server Uptime (sec)", curUptime, deltaStats);
-        if (prevUptime != null) {
-            printCollectiveObservedCurrent(metricPrefix + "Availability|Server Uptime (sec) Delta", getDeltaValue(curUptime, prevUptime));
-        }
 
         //Resource Utilization
         String curCpuLoad = round(valueMap.get("CPULoad"));

--- a/src/main/java/com/appdynamics/monitors/apache/ApacheStatusMonitor.java
+++ b/src/main/java/com/appdynamics/monitors/apache/ApacheStatusMonitor.java
@@ -459,7 +459,7 @@ public class ApacheStatusMonitor extends AManagedMonitor {
         printCollectiveObservedCurrent(metricPrefix + "Activity|Total Accesses", curTotalAccesses);
         BigInteger prevTotalAccesses = processDelta(metricPrefix + "Activity|Total Accesses", curTotalAccesses, deltaStats);
         if (prevTotalAccesses != null) {
-            printCollectiveObservedCurrent(metricPrefix + "Activity|Total Accesses Delta", getDeltaValue(curTotalAccesses, prevTotalAccesses));
+            printCollectiveObservedAverage(metricPrefix + "Activity|Total Accesses Delta", getDeltaValue(curTotalAccesses, prevTotalAccesses));
         }
 
 
@@ -467,7 +467,7 @@ public class ApacheStatusMonitor extends AManagedMonitor {
         printCollectiveObservedCurrent(metricPrefix + "Activity|Total Traffic", curTotalKBytes);
         BigInteger prevTotalKBytes = processDelta(metricPrefix + "Activity|Total Traffic", curTotalKBytes, deltaStats);
         if (prevTotalKBytes != null) {
-            printCollectiveObservedCurrent(metricPrefix + "Activity|Total Traffic Delta", getDeltaValue(curTotalKBytes, prevTotalKBytes));
+            printCollectiveObservedAverage(metricPrefix + "Activity|Total Traffic Delta", getDeltaValue(curTotalKBytes, prevTotalKBytes));
         }
 
 


### PR DESCRIPTION
Deltas need to report the average, not current rollup, so that the average, min and max delta over a given period is known..

Also, having a server uptime delta doesn't make sense.
