### PR TITLE
v2.0.5 - Update appd-exts-commons to v2.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # AppDynamics Extensions Apache CHANGELOG
 
+## 2.0.5 - Feb 2, 2023
+1. Updated to appd-exts-commons 2.2.8
+
 ## 2.0.4 - Jan 4, 2021
 1. Updated to appd-exts-commons 2.2.4
 

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ Always feel free to fork and contribute any changes directly here on [GitHub](ht
 ## Version
 |          Name            |  Version   |
 |--------------------------|------------|
-|Extension Version         |2.0.4       |
-|Product Tested On         |4.5.12+     |
-|Last Update               |04/01/2021  |
+|Extension Version         |2.0.5       |
+|Product Tested On         |4.5.13+     |
+|Last Update               |02/02/2023  |
 |Changes list              |[ChangeLog](https://github.com/Appdynamics/apache-monitoring-extension/blob/master/CHANGELOG.md)|
 
 **Note**: While extensions are maintained and supported by customers under the open-source licensing model, they interact with agents and Controllers that are subject to [AppDynamics’ maintenance and support policy](https://docs.appdynamics.com/latest/en/product-and-release-announcements/maintenance-support-for-software-versions). Some extensions have been tested with AppDynamics 4.5.13+ artifacts, but you are strongly recommended against using versions that are no longer supported.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.appdynamics.extensions</groupId>
     <artifactId>apache-monitoring-extension</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <packaging>jar</packaging>
 
     <name>apache-monitoring-extension</name>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.appdynamics</groupId>
             <artifactId>appd-exts-commons</artifactId>
-            <version>2.2.4</version>
+            <version>2.2.8</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>


### PR DESCRIPTION
Some security vulnerabilities have been detected in actual version of **maven-repo** (see Pull Request [maven-repo !2](../../maven-repo/pull/2))

Therefore we suggest to upgrade **appd-exts-commons** dependencies to version **2.2.8**
